### PR TITLE
Fix: link to edit example content

### DIFF
--- a/src/components/examples/ExamplesFooter.tsx
+++ b/src/components/examples/ExamplesFooter.tsx
@@ -5,7 +5,7 @@ import { format } from 'date-fns'
 import { Doc, Example } from 'contentlayer/generated'
 
 const githubBranch = 'main'
-const githubBaseUrl = `https://github.com/contentlayerdev/website/blob/${githubBranch}/examples/`
+const githubBaseUrl = `https://github.com/contentlayerdev/website/blob/${githubBranch}/content/`
 
 export const ExamplesFooter: FC<{ example: Example }> = ({ example }) => {
   return (


### PR DESCRIPTION
Small change to address the update to the `githubBaseUrl` to redirect properly from the `Edit this page` link in the examples footers. 