### PR TITLE
Fix a broken link

### DIFF
--- a/content/docs/500-reference/200-source-files/200-define-document-type.mdx
+++ b/content/docs/500-reference/200-source-files/200-define-document-type.mdx
@@ -38,7 +38,7 @@ In the usage example, the `name` was `Doc`, which would generate a data object `
 
 ### `fields`
 
-Field definitions determine the data shape for the document type. See [the field types reference](https://www.contentlayer.dev/docs/reference/source-files/field-types) for more information.
+Field definitions determine the data shape for the document type. See [the field types reference](/docs/reference/source-files/field-types) for more information.
 
 ### `description`
 

--- a/content/docs/500-reference/200-source-files/200-define-document-type.mdx
+++ b/content/docs/500-reference/200-source-files/200-define-document-type.mdx
@@ -38,7 +38,7 @@ In the usage example, the `name` was `Doc`, which would generate a data object `
 
 ### `fields`
 
-Field definitions determine the data shape for the document type. See [the field types reference](./field-types) for more information.
+Field definitions determine the data shape for the document type. See [the field types reference](https://www.contentlayer.dev/docs/reference/source-files/field-types) for more information.
 
 ### `description`
 


### PR DESCRIPTION
The link `the field types reference` page was leading to a 404 error. This change points it to the right place.