### PR TITLE
fix define nested type broken link

### DIFF
--- a/content/docs/500-reference/200-source-files/400-field-types.mdx
+++ b/content/docs/500-reference/200-source-files/400-field-types.mdx
@@ -126,7 +126,7 @@ A list is an array of values that can be either strings or nested objects.
 **Options:**
 
 - `default` (`array`): A list of default values.
-- `of` (`NestedType`): A nested document type definition. [Learn more about nested types](./define-nested-type).
+- `of` (`NestedType`): A nested document type definition. [Learn more about nested types](./reference/source-files/define-nested-type).
 
 **Example:**
 


### PR DESCRIPTION
There seems to be a broken link "**Learn more about nested types**" on the `field-types` page.

Please let me know if there are any extra steps in order for me to fix it.

<img width="1111" alt="Screenshot 2022-05-07 at 18 14 56" src="https://user-images.githubusercontent.com/11808448/167262810-9fcf1378-8441-44f2-b5b0-4ecf468b3149.png">
