### PR TITLE
Fix broken link in docs

### DIFF
--- a/content/docs/300-sources/100-files/300-generated-types.mdx
+++ b/content/docs/300-sources/100-files/300-generated-types.mdx
@@ -3,7 +3,7 @@ title: Generated Type Definitions
 excerpt: Contentlayer automatically generates type definitions for content that lives locally.
 ---
 
-Alongside your [generated documents](./generated-data) you'll find a `types` file at `.contentlayer/generated/index.d.ts`.
+Alongside your [generated documents](/docs/sources/files/generated-data) you'll find a `types` file at `.contentlayer/generated/index.d.ts`.
 
 This file exports a number of auto-generated and provided types that you can use to ensure type safety throughout your application.
 


### PR DESCRIPTION
## Fix 404 link in docs

[Generated documents](https://www.contentlayer.dev/docs/sources/files/generated-data) link in ["Generated Type Definitions"](https://www.contentlayer.dev/docs/sources/files/generated-types) should point to `/docs/sources/files/generated-data` not to `/docs/generated-data`.


Docs: https://www.contentlayer.dev/docs/sources/files/generated-types
Source File: https://github.com/contentlayerdev/website/blob/main/content/docs/300-sources/100-files/300-generated-types.mdx?plain=1#L6

