### PR TITLE
Fix invalid "as" for default export.

### DIFF
--- a/content/docs/400-environments/100-nextjs.mdx
+++ b/content/docs/400-environments/100-nextjs.mdx
@@ -34,7 +34,7 @@ If you want to use `next/image` to render your images, create a component to wra
 For example, say we have an `Image` component in our project that wraps the `next/image`.
 
 ```jsx
-import Image as NextImage from 'next/image'
+import NextImage from 'next/image'
 
 const Image = (props) => {
   return <NextImage /* ... */ />


### PR DESCRIPTION
`Image` for `next/image` is a default export so there's no need to use `as` with it - nor are you even allowed to, anyway! You can rename it to `NextImage` in the import declaration straightaway. 👍