### PR TITLE
docs: clarify configuration more clear

### DIFF
--- a/content/docs/100-getting-started/index.mdx
+++ b/content/docs/100-getting-started/index.mdx
@@ -52,14 +52,22 @@ npm install contentlayer next-contentlayer
 
 To hook Contentlayer into the `next dev` and `next build` processes, you'll want to wrap the Next.js configuration using the `withContentlayer` method.
 
-Create a new file called `next.config.mjs` in the root of your project, and add the following content.
+Create a new file called `next.config.js` in the root of your project, and add the following content.
 
 ```js
-// next.config.mjs
+// next.config.js
 
-import { withContentlayer } from 'next-contentlayer'
+const { withContentlayer } = require("next-contentlayer")
 
-export default withContentlayer({})
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+  // Optionally, add any other Next.js config below
+  ...
+}
+
+module.exports = withContentlayer(nextConfig)
 ```
 
 Then add the following lines to your `tsconfig.json` or `jsconfig.json` file:


### PR DESCRIPTION
Modify `next.config.mjs` to `next.config.js`, because  `next.config.js` is default generated by `npx create-next-app@latest --typescript`, which is the official recommanded way to create Next.js project.

```js
// next.config.js

/** @type {import('next').NextConfig} */
const nextConfig = {
  reactStrictMode: true,
  swcMinify: true,
}

module.exports = nextConfig
```
Clarify the configuration of `withContentlayer` in `next.config.js` more clear.

```js
// next.config.js

const { withContentlayer } = require("next-contentlayer")

/** @type {import('next').NextConfig} */
const nextConfig = {
  reactStrictMode: true,
  swcMinify: true,
  // Optionally, add any other Next.js config below
  ...
}

module.exports = withContentlayer(nextConfig)
```