### PR TITLE
docs (Notion): Rename makeSource option

### DIFF
--- a/content/docs/300-sources/125-notion/100-getting-started.mdx
+++ b/content/docs/300-sources/125-notion/100-getting-started.mdx
@@ -81,7 +81,7 @@ const client = new Client({ auth: process.env.NOTION_TOKEN })
 
 export default makeSource({
   client,
-  documentTypes: [],
+  databaseTypes: [],
 })
 ```
 
@@ -129,7 +129,7 @@ export const Post = defineDatabase(() => ({
 
 export default makeSource({
   client,
-  documentTypes: [Post],
+  databaseTypes: [Post],
 })
 ```
 


### PR DESCRIPTION
`makeSource` in the Notion integration takes a required option called `databaseTypes` instead of `documentTypes` used elsewhere. This updates the documentation to reflect the correct field name. This took me way too long to notice since my Contentlayer config file was a JavaScript file and I wasn't seeing the type error.