### PR TITLE
Change 1 sentence

### DIFF
--- a/content/docs/300-sources/100-files/100-mapping-document-types.mdx
+++ b/content/docs/300-sources/100-files/100-mapping-document-types.mdx
@@ -66,7 +66,7 @@ type: Page
 
 Note that regardless of whether or not you are explicitly defining the type on individual documents, you should still stay true to the `filePathPattern` option for that document type's definition.
 
-Following the example above, if you've specified the `filePathPattern` as `posts/**/*.mdx` and the type as `Post`, you don't want to place a document of type `Post` in a directory outside `posts` or without an `.mdx` file extension. If you do, Contentlayer may process the file.
+Following the example above, if you've specified the `filePathPattern` as `posts/**/*.mdx` and the type as `Post`, you don't want to place a document of type `Post` in a directory outside `posts` or without an `.mdx` file extension. If you do, Contentlayer may not process the file.
 
 ```txt
 /


### PR DESCRIPTION
This:
you don't want to place a document of type `Post` in a directory outside `posts` or without an `.mdx` file extension. If you do, Contentlayer may **not** process the file.

Added the "not" but maybe i am just wrong