### PR TITLE
By default NextJS doesn't has a "module" next.config.js

### DIFF
--- a/content/docs/500-reference/200-next-contentlayer.mdx
+++ b/content/docs/500-reference/200-next-contentlayer.mdx
@@ -14,10 +14,11 @@ To enable it, add the following to your `next.config.js` file:
 
 ```js
 // next.config.js
+const { withContentlayer } = require("next-contentlayer");
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
 
-import { withContentlayer } from 'next-contentlayer'
-
-export default withContentlayer({})
+export default withContentlayer(nextConfig)
 ```
 
 ## `useMDXComponent`


### PR DESCRIPTION
By default NextJS doesn't has a "module" next.config.js, copying this instruction throws error  
`
SyntaxError: Cannot use import statement outside a module
`