### PR TITLE
By default NextJS doesn't has a "module" type next config

### DIFF
--- a/content/docs/500-reference/200-next-contentlayer.mdx
+++ b/content/docs/500-reference/200-next-contentlayer.mdx
@@ -15,9 +15,9 @@ To enable it, add the following to your `next.config.js` file:
 ```js
 // next.config.js
 
-import { withContentlayer } from 'next-contentlayer'
+const { withContentlayer } = require("next-contentlayer");
 
-export default withContentlayer({})
+module.exports = withContentlayer(nextConfig);
 ```
 
 ## `useMDXComponent`


### PR DESCRIPTION
Copying the previous instruction , throws error 
`
import { withContentlayer } from 'next-contentlayer'
^^^^^^
SyntaxError: Cannot use import statement outside a module
`
